### PR TITLE
Add logo to header

### DIFF
--- a/index.html
+++ b/index.html
@@ -26,6 +26,7 @@ h2{font-size:28px;margin:0 0 14px;font-weight:800}
 }
 .kicker{color:var(--muted);font-size:14px;margin:0 0 10px}
 .sub{color:var(--muted)}
+.logo{height:60px;display:block;margin-bottom:16px}
 .btnbar{display:flex;gap:12px;flex-wrap:wrap;margin-top:16px}
 .btn{background:var(--brand);color:#fff;padding:10px 14px;border-radius:10px;font-weight:700}
 .btn.alt{background:#fff;color:var(--brand);border:1px solid var(--brand)}
@@ -81,6 +82,7 @@ h2{font-size:28px;margin:0 0 14px;font-weight:800}
 <body>
 <header class="header">
   <div class="wrapper">
+    <img src="fp1-dark-.png" alt="FairParKen Logo" class="logo" />
     <p class="kicker">Kundenservice · Führung · Prozesse · Digitalisierung</p>
     <h1>Teamleitung Kundenservice – Vorgehensplan & Wirkung</h1>
     <p class="sub">Ein pragmatischer, messbarer Fahrplan – vom ersten Tag bis zur etablierten Teamkultur.</p>


### PR DESCRIPTION
## Summary
- Insert FairParKen logo image into page header
- Add CSS styling for logo display and spacing

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b21c85cce8833290dff74706e017b0